### PR TITLE
OPENTOK-35469: Windows SDK screensharing sample code does not work on Windows 7 so update documentation. r=jeffswartz

### DIFF
--- a/ScreenSharing/README.md
+++ b/ScreenSharing/README.md
@@ -8,6 +8,11 @@ the content of the screen as the video source for an OpenTok publisher.
 [Quick Start](../README.md#quick-start) section of the main README file
 for this repository.
 
+Application Notes
+-----------------
+  * This application uses Microsoft DirectX graphics APIs not supported on
+    Windows 7 so this sample code works on Windows 8+.
+
 ScreenSharingCapturer.cs
 ------------------------
 

--- a/ScreenSharing/README.md
+++ b/ScreenSharing/README.md
@@ -10,8 +10,8 @@ for this repository.
 
 Application Notes
 -----------------
-  * This application uses Microsoft DirectX graphics APIs not supported on
-    Windows 7 so this sample code works on Windows 8+.
+  * This application uses Microsoft DirectX graphics APIs, which are not supported on
+    Windows 7. This sample code works on Windows 8+.
 
 ScreenSharingCapturer.cs
 ------------------------


### PR DESCRIPTION
#### What is this PR doing?

Adding a note in the README.md file from the screen sharing sample to tell the developer the sample code does not work on Windows 7.

#### How should this be manually tested?

NA.

#### What are the relevant tickets?

[OPENTOK-35469](https://tokbox.atlassian.net/browse/OPENTOK-35469)
