### PR TITLE
Use Trace.WriteLine instead of Console.WriteLine.

### DIFF
--- a/BasicVideoChat/MainWindow.xaml.cs
+++ b/BasicVideoChat/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using OpenTok;
 using System;
+using System.Diagnostics;
 using System.Windows;
 
 namespace BasicVideoChat
@@ -34,12 +35,12 @@ namespace BasicVideoChat
  
         private void Session_Disconnected(object sender, System.EventArgs e)
         {
-            Console.WriteLine("Session disconnected.");
+            Trace.WriteLine("Session disconnected.");
         }
 
         private void Session_Error(object sender, Session.ErrorEventArgs e)
         {
-            Console.WriteLine("Session error:" + e.ErrorCode);
+            Trace.WriteLine("Session error:" + e.ErrorCode);
         }
 
         private void Session_StreamReceived(object sender, Session.StreamEventArgs e)

--- a/CustomVideoRenderer/MainWindow.xaml.cs
+++ b/CustomVideoRenderer/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using OpenTok;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Windows;
 
 namespace CustomVideoRenderer
@@ -31,12 +32,12 @@ namespace CustomVideoRenderer
             if (devices.Count > 0)
             {
                 var selectedDevice = devices[0];
-                Console.WriteLine("Using camera: " + devices[0].Name);
+                Trace.WriteLine("Using camera: " + devices[0].Name);
                 Capturer = selectedDevice.CreateVideoCapturer(VideoCapturer.Resolution.High);
             }
             else
             {
-                Console.WriteLine("Warning: no cameras available, the publisher will be audio only.");
+                Trace.WriteLine("Warning: no cameras available, the publisher will be audio only.");
             }
 
             // We create the publisher here to show the preview when application starts
@@ -82,13 +83,13 @@ namespace CustomVideoRenderer
             }
             catch (OpenTokException ex)
             {
-                Console.WriteLine("OpenTokException " + ex.ToString());
+                Trace.WriteLine("OpenTokException " + ex.ToString());
             }
         }
 
         private void Session_Disconnected(object sender, EventArgs e)
         {
-            Console.WriteLine("Session disconnected");
+            Trace.WriteLine("Session disconnected");
             SubscriberByStream.Clear();
             SubscriberGrid.Children.Clear();
         }
@@ -108,7 +109,7 @@ namespace CustomVideoRenderer
 
         private void Session_StreamReceived(object sender, Session.StreamEventArgs e)
         {
-            Console.WriteLine("Session stream received");
+            Trace.WriteLine("Session stream received");
 
             SampleVideoRenderer renderer = new SampleVideoRenderer();
             renderer.EnableBlueFilter = PublisherVideo.EnableBlueFilter;
@@ -124,13 +125,13 @@ namespace CustomVideoRenderer
             }
             catch (OpenTokException ex)
             {
-                Console.WriteLine("OpenTokException " + ex.ToString());
+                Trace.WriteLine("OpenTokException " + ex.ToString());
             }
         }
 
         private void Session_StreamDropped(object sender, Session.StreamEventArgs e)
         {
-            Console.WriteLine("Session stream dropped");
+            Trace.WriteLine("Session stream dropped");
             var subscriber = SubscriberByStream[e.Stream];
             if (subscriber != null)
             {
@@ -141,7 +142,7 @@ namespace CustomVideoRenderer
                 }
                 catch (OpenTokException ex)
                 {
-                    Console.WriteLine("OpenTokException " + ex.ToString());
+                    Trace.WriteLine("OpenTokException " + ex.ToString());
                 }
 
                 SubscriberGrid.Children.Remove((UIElement)subscriber.VideoRenderer);
@@ -153,7 +154,7 @@ namespace CustomVideoRenderer
         {
             if (Disconnect)
             {
-                Console.WriteLine("Disconnecting session");
+                Trace.WriteLine("Disconnecting session");
                 try
                 {
                     Session.Unpublish(Publisher);
@@ -161,19 +162,19 @@ namespace CustomVideoRenderer
                 }
                 catch (OpenTokException ex)
                 {
-                    Console.WriteLine("OpenTokException " + ex.ToString());
+                    Trace.WriteLine("OpenTokException " + ex.ToString());
                 }
             }
             else
             {
-                Console.WriteLine("Connecting session");
+                Trace.WriteLine("Connecting session");
                 try
                 {
                     Session.Connect(TOKEN);
                 }
                 catch (OpenTokException ex)
                 {
-                    Console.WriteLine("OpenTokException " + ex.ToString());
+                    Trace.WriteLine("OpenTokException " + ex.ToString());
                 }
             }
             Disconnect = !Disconnect;

--- a/ScreenSharing/MainWindow.xaml.cs
+++ b/ScreenSharing/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using OpenTok;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Windows;
 
 namespace ScreenSharing
@@ -73,13 +74,13 @@ namespace ScreenSharing
             }
             catch (OpenTokException ex)
             {
-                Console.WriteLine("OpenTokException " + ex.ToString());
+                Trace.WriteLine("OpenTokException " + ex.ToString());
             }
         }
 
         private void Session_Disconnected(object sender, EventArgs e)
         {
-            Console.WriteLine("Session disconnected");
+            Trace.WriteLine("Session disconnected");
             SubscriberByStream.Clear();
             SubscriberGrid.Children.Clear();
         }
@@ -99,7 +100,7 @@ namespace ScreenSharing
 
         private void Session_StreamReceived(object sender, Session.StreamEventArgs e)
         {
-            Console.WriteLine("Session stream received");
+            Trace.WriteLine("Session stream received");
             VideoRenderer renderer = new VideoRenderer();
             SubscriberGrid.Children.Add(renderer);
             UpdateGridSize(SubscriberGrid.Children.Count);
@@ -112,13 +113,13 @@ namespace ScreenSharing
             }
             catch (OpenTokException ex)
             {
-                Console.WriteLine("OpenTokException " + ex.ToString());
+                Trace.WriteLine("OpenTokException " + ex.ToString());
             }
         }
 
         private void Session_StreamDropped(object sender, Session.StreamEventArgs e)
         {
-            Console.WriteLine("Session stream dropped");
+            Trace.WriteLine("Session stream dropped");
             var subscriber = SubscriberByStream[e.Stream];
             if (subscriber != null)
             {
@@ -129,7 +130,7 @@ namespace ScreenSharing
                 }
                 catch (OpenTokException ex)
                 {
-                    Console.WriteLine("OpenTokException " + ex.ToString());
+                    Trace.WriteLine("OpenTokException " + ex.ToString());
                 }
 
                 SubscriberGrid.Children.Remove((UIElement)subscriber.VideoRenderer);
@@ -141,7 +142,7 @@ namespace ScreenSharing
         {
             if (Disconnect)
             {
-                Console.WriteLine("Disconnecting session");
+                Trace.WriteLine("Disconnecting session");
                 try
                 {
                     Session.Unpublish(Publisher);
@@ -149,19 +150,19 @@ namespace ScreenSharing
                 }
                 catch (OpenTokException ex)
                 {
-                    Console.WriteLine("OpenTokException " + ex.ToString());
+                    Trace.WriteLine("OpenTokException " + ex.ToString());
                 }
             }
             else
             {
-                Console.WriteLine("Connecting session");
+                Trace.WriteLine("Connecting session");
                 try
                 {
                     Session.Connect(TOKEN);
                 }
                 catch (OpenTokException ex)
                 {
-                    Console.WriteLine("OpenTokException " + ex.ToString());
+                    Trace.WriteLine("OpenTokException " + ex.ToString());
                 }
             }
             Disconnect = !Disconnect;

--- a/SimpleMultiparty/MainWindow.xaml.cs
+++ b/SimpleMultiparty/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using OpenTok;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Windows;
 
 namespace SimpleMultiparty
@@ -31,12 +32,12 @@ namespace SimpleMultiparty
             if (devices.Count > 0)
             {
                 var selectedDevice = devices[0];
-                Console.WriteLine("Using camera: " + devices[0].Name);
+                Trace.WriteLine("Using camera: " + devices[0].Name);
                 Capturer = selectedDevice.CreateVideoCapturer(VideoCapturer.Resolution.High);
             }
             else
             {
-                Console.WriteLine("Warning: no cameras available, the publisher will be audio only.");
+                Trace.WriteLine("Warning: no cameras available, the publisher will be audio only.");
             }
 
             // We create the publisher here to show the preview when application starts
@@ -82,13 +83,13 @@ namespace SimpleMultiparty
             }
             catch (OpenTokException ex)
             {
-                Console.WriteLine("OpenTokException " + ex.ToString());
+                Trace.WriteLine("OpenTokException " + ex.ToString());
             }
         }
 
         private void Session_Disconnected(object sender, EventArgs e)
         {
-            Console.WriteLine("Session disconnected");
+            Trace.WriteLine("Session disconnected");
             SubscriberByStream.Clear();
             SubscriberGrid.Children.Clear();
         }
@@ -108,7 +109,7 @@ namespace SimpleMultiparty
 
         private void Session_StreamReceived(object sender, Session.StreamEventArgs e)
         {
-            Console.WriteLine("Session stream received");
+            Trace.WriteLine("Session stream received");
 
             VideoRenderer renderer = new VideoRenderer();
             SubscriberGrid.Children.Add(renderer);
@@ -122,13 +123,13 @@ namespace SimpleMultiparty
             }
             catch (OpenTokException ex)
             {
-                Console.WriteLine("OpenTokException " + ex.ToString());
+                Trace.WriteLine("OpenTokException " + ex.ToString());
             }
         }
 
         private void Session_StreamDropped(object sender, Session.StreamEventArgs e)
         {
-            Console.WriteLine("Session stream dropped");
+            Trace.WriteLine("Session stream dropped");
             var subscriber = SubscriberByStream[e.Stream];
             if (subscriber != null)
             {
@@ -139,7 +140,7 @@ namespace SimpleMultiparty
                 }
                 catch (OpenTokException ex)
                 {
-                    Console.WriteLine("OpenTokException " + ex.ToString());
+                    Trace.WriteLine("OpenTokException " + ex.ToString());
                 }
 
                 SubscriberGrid.Children.Remove((UIElement)subscriber.VideoRenderer);
@@ -151,7 +152,7 @@ namespace SimpleMultiparty
         {
             if (Disconnect)
             {
-                Console.WriteLine("Disconnecting session");
+                Trace.WriteLine("Disconnecting session");
                 try
                 {
                     Session.Unpublish(Publisher);
@@ -159,19 +160,19 @@ namespace SimpleMultiparty
                 }
                 catch (OpenTokException ex)
                 {
-                    Console.WriteLine("OpenTokException " + ex.ToString());
+                    Trace.WriteLine("OpenTokException " + ex.ToString());
                 }
             }
             else
             {
-                Console.WriteLine("Connecting session");
+                Trace.WriteLine("Connecting session");
                 try
                 {
                     Session.Connect(TOKEN);
                 }
                 catch (OpenTokException ex)
                 {
-                    Console.WriteLine("OpenTokException " + ex.ToString());
+                    Trace.WriteLine("OpenTokException " + ex.ToString());
                 }
             }
             Disconnect = !Disconnect;

--- a/SimpleMultiparty/MainWindow.xaml.cs
+++ b/SimpleMultiparty/MainWindow.xaml.cs
@@ -96,6 +96,7 @@ namespace SimpleMultiparty
 
         private void Session_Error(object sender, Session.ErrorEventArgs e)
         {
+            Trace.WriteLine("Session error:" + e.ErrorCode);
             MessageBox.Show("Session error:" + e.ErrorCode, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
         }
 


### PR DESCRIPTION
Console message are just lost in windowed applications.
Even in console applications, Console output is not handy at all: not easily redirected to log, and copy-paste is clumsy.

On the contrary, Trace naturally appears in debugger, is easily duplicated to logs via .NET trace listeners. Ref e.g. https://docs.microsoft.com/en-us/dotnet/framework/debug-trace-profile/tracing-and-instrumenting-applications
