### PR TITLE
VIDCS-765: Update OPENTOK version on windows-sdk-samples using 2.25.0

### DIFF
--- a/BasicVideoChat/packages.config
+++ b/BasicVideoChat/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenTok.Client" version="2.24.0" targetFramework="net452" />
+  <package id="OpenTok.Client" version="2.25.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Hi, OPENTOK version on Basic-Video-Chat/Windows-SDK-Samples is updated in this pr.