### PR TITLE
VIDCS-887 :Update opentok-windows-sdk-samples to use 2.25.1

### DIFF
--- a/BasicVideoChat/packages.config
+++ b/BasicVideoChat/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenTok.Client" version="2.25.0" targetFramework="net452" />
+  <package id="OpenTok.Client" version="2.25.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Hi , packages.config on Basic-Video-Chat was updated using 2.25.1 in this pr.