### PR TITLE
VIDCS-2636 Upgrade nuget package reference system from packages.config to PackageReference

### DIFF
--- a/AudioDeviceNotifications/AudioDeviceNotifications.csproj
+++ b/AudioDeviceNotifications/AudioDeviceNotifications.csproj
@@ -104,7 +104,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/AudioDeviceNotifications/AudioDeviceNotifications.csproj
+++ b/AudioDeviceNotifications/AudioDeviceNotifications.csproj
@@ -39,9 +39,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTokNetStandard, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\<OpenTok class="Client 2 28 1"></OpenTok>\lib\net462\OpenTokNetStandard.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
@@ -56,12 +53,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="WinFormsVideoRenderer, Version=2.28.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\<OpenTok class="Client 2 28 1"></OpenTok>\lib\net462\WinFormsVideoRenderer.dll</HintPath>
-    </Reference>
-    <Reference Include="WPFVideoRenderer, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\<OpenTok class="Client 2 28 1"></OpenTok>\lib\net462\WPFVideoRenderer.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -128,6 +119,10 @@
     <Resource Include="Headphones.png" />
     <Resource Include="Mic.png" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTok.Client">
+      <Version>2.28.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\OpenTok.Client.2.28.1\build\OpenTok.Client.targets" />
 </Project>

--- a/AudioDeviceNotifications/packages.config
+++ b/AudioDeviceNotifications/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="OpenTok.Client" version="2.28.1" targetFramework="net462" />
-</packages>

--- a/AudioRecording/AudioRecording.csproj
+++ b/AudioRecording/AudioRecording.csproj
@@ -89,7 +89,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/AudioRecording/AudioRecording.csproj
+++ b/AudioRecording/AudioRecording.csproj
@@ -38,9 +38,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTokNetStandard, Version=2.28.0.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.0\lib\net462\OpenTokNetStandard.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
@@ -55,12 +52,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="WinFormsVideoRenderer, Version=2.28.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.0\lib\net462\WinFormsVideoRenderer.dll</HintPath>
-    </Reference>
-    <Reference Include="WPFVideoRenderer, Version=2.28.0.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.0\lib\net462\WPFVideoRenderer.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -107,6 +98,10 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTok.Client">
+      <Version>2.28.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\OpenTok.Client.2.28.0\build\OpenTok.Client.targets" />
 </Project>

--- a/AudioRecording/packages.config
+++ b/AudioRecording/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="OpenTok.Client" version="2.28.0" targetFramework="net462" />
-</packages>

--- a/BasicVideoChat/BasicVideoChat.csproj
+++ b/BasicVideoChat/BasicVideoChat.csproj
@@ -90,7 +90,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/BasicVideoChat/BasicVideoChat.csproj
+++ b/BasicVideoChat/BasicVideoChat.csproj
@@ -39,9 +39,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTokNetStandard, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\OpenTokNetStandard.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
@@ -56,12 +53,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="WinFormsVideoRenderer, Version=2.28.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\WinFormsVideoRenderer.dll</HintPath>
-    </Reference>
-    <Reference Include="WPFVideoRenderer, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\WPFVideoRenderer.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -110,6 +101,10 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTok.Client">
+      <Version>2.28.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\OpenTok.Client.2.28.1\build\OpenTok.Client.targets" />  
 </Project>

--- a/BasicVideoChat/packages.config
+++ b/BasicVideoChat/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="OpenTok.Client" version="2.28.1" targetFramework="net462" />
-</packages>

--- a/CustomVideoRenderer/CustomVideoRenderer.csproj
+++ b/CustomVideoRenderer/CustomVideoRenderer.csproj
@@ -96,7 +96,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/CustomVideoRenderer/CustomVideoRenderer.csproj
+++ b/CustomVideoRenderer/CustomVideoRenderer.csproj
@@ -39,9 +39,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTokNetStandard, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\OpenTokNetStandard.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -57,12 +54,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="WinFormsVideoRenderer, Version=2.28.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\WinFormsVideoRenderer.dll</HintPath>
-    </Reference>
-    <Reference Include="WPFVideoRenderer, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\WPFVideoRenderer.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -116,6 +107,10 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTok.Client">
+      <Version>2.28.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\OpenTok.Client.2.28.1\build\OpenTok.Client.targets" />
 </Project>

--- a/CustomVideoRenderer/packages.config
+++ b/CustomVideoRenderer/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="OpenTok.Client" version="2.28.1" targetFramework="net462" />
-</packages>

--- a/FileAudioSource/FileAudioSource.csproj
+++ b/FileAudioSource/FileAudioSource.csproj
@@ -92,7 +92,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/FileAudioSource/FileAudioSource.csproj
+++ b/FileAudioSource/FileAudioSource.csproj
@@ -40,9 +40,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTokNetStandard, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\OpenTokNetStandard.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
@@ -57,12 +54,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="WinFormsVideoRenderer, Version=2.28.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\WinFormsVideoRenderer.dll</HintPath>
-    </Reference>
-    <Reference Include="WPFVideoRenderer, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\WPFVideoRenderer.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -111,6 +102,10 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTok.Client">
+      <Version>2.28.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\OpenTok.Client.2.28.1\build\OpenTok.Client.targets" />
 </Project>

--- a/FileAudioSource/packages.config
+++ b/FileAudioSource/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="OpenTok.Client" version="2.28.1" targetFramework="net462" />
-</packages>

--- a/FrameMetadata/FrameMetadata.csproj
+++ b/FrameMetadata/FrameMetadata.csproj
@@ -96,7 +96,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/FrameMetadata/FrameMetadata.csproj
+++ b/FrameMetadata/FrameMetadata.csproj
@@ -38,15 +38,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTokNetStandard, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\OpenTokNetStandard.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Drawing.Common, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Drawing.Common.8.0.0\lib\net462\System.Drawing.Common.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
@@ -59,12 +53,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="WinFormsVideoRenderer, Version=2.28.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\WinFormsVideoRenderer.dll</HintPath>
-    </Reference>
-    <Reference Include="WPFVideoRenderer, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\WPFVideoRenderer.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -119,6 +107,13 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTok.Client">
+      <Version>2.28.1</Version>
+    </PackageReference>
+    <PackageReference Include="System.Drawing.Common">
+      <Version>8.0.8</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\OpenTok.Client.2.28.1\build\OpenTok.Client.targets" />
 </Project>

--- a/FrameMetadata/packages.config
+++ b/FrameMetadata/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="OpenTok.Client" version="2.28.1" targetFramework="net462" />
-  <package id="System.Drawing.Common" version="8.0.0" targetFramework="net462" />
-</packages>

--- a/SimpleMultiparty/SimpleMultiparty.csproj
+++ b/SimpleMultiparty/SimpleMultiparty.csproj
@@ -87,9 +87,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTokNetStandard, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\OpenTokNetStandard.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -105,12 +102,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="WinFormsVideoRenderer, Version=2.28.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\WinFormsVideoRenderer.dll</HintPath>
-    </Reference>
-    <Reference Include="WPFVideoRenderer, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\WPFVideoRenderer.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -162,6 +153,10 @@
   <ItemGroup>
     <Folder Include="Themes\" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTok.Client">
+      <Version>2.28.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\OpenTok.Client.2.28.1\build\OpenTok.Client.targets" />
 </Project>

--- a/SimpleMultiparty/SimpleMultiparty.csproj
+++ b/SimpleMultiparty/SimpleMultiparty.csproj
@@ -139,7 +139,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/SimpleMultiparty/packages.config
+++ b/SimpleMultiparty/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="OpenTok.Client" version="2.28.1" targetFramework="net462" />
-</packages>

--- a/Transformers/Transformers.csproj
+++ b/Transformers/Transformers.csproj
@@ -94,7 +94,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/Transformers/Transformers.csproj
+++ b/Transformers/Transformers.csproj
@@ -41,9 +41,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTokNetStandard, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\OpenTokNetStandard.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -60,12 +57,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="WinFormsVideoRenderer, Version=2.28.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\WinFormsVideoRenderer.dll</HintPath>
-    </Reference>
-    <Reference Include="WPFVideoRenderer, Version=2.28.1.0, Culture=neutral, PublicKeyToken=446993dbb1ae17c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTok.Client.2.28.1\lib\net462\WPFVideoRenderer.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -119,7 +110,13 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTok.Client">
+      <Version>2.28.1</Version>
+    </PackageReference>
+	<PackageReference Include="Vonage.Client.Video.Transformers">
+      <Version>2.28.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\OpenTok.Client.2.28.1\build\OpenTok.Client.targets" />
-  <Import Project="..\packages\Vonage.Client.Video.Transformers.2.28.1\build\Vonage.Client.Video.Transformers.targets" />
 </Project>

--- a/Transformers/packages.config
+++ b/Transformers/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="OpenTok.Client" version="2.28.1" targetFramework="net462" />
-  <package id="Vonage.Client.Video.Transformers" version="2.28.1" targetFramework="net462" />
-</packages>


### PR DESCRIPTION
Upgrade nuget package reference system from packages.config to PackageReference.
Apart from being a reasonable upgrade since it get's rid of a legacy system. It also fixes the issue where we need to call nuget restore Samples.sln before loading the solution.